### PR TITLE
Inverse relations

### DIFF
--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -266,6 +266,7 @@ class TransE(DistanceBasedScoreFunction):
         relation_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
             init_KGE_uniform
         ],
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize TransE model.
@@ -284,6 +285,8 @@ class TransE(DistanceBasedScoreFunction):
             Initialization function or table for entity embeddings.
         :param relation_initializer:
             Initialization function or table for relation embeddings.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(TransE, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -295,7 +298,7 @@ class TransE(DistanceBasedScoreFunction):
             self.sharding, entity_initializer, [embedding_size]
         )
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [embedding_size]
+            n_relation_type, inverse_relations, relation_initializer, [embedding_size]
         )
         assert (
             self.entity_embedding.shape[-1]
@@ -362,6 +365,7 @@ class RotatE(DistanceBasedScoreFunction):
         relation_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
             init_KGE_uniform
         ],
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize RotatE model.
@@ -381,6 +385,8 @@ class RotatE(DistanceBasedScoreFunction):
             Initialization function or table for entity embeddings.
         :param relation_initializer:
             Initialization function or table for relation embeddings.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(RotatE, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -394,7 +400,7 @@ class RotatE(DistanceBasedScoreFunction):
             self.sharding, entity_initializer, [2 * embedding_size]
         )
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [embedding_size]
+            n_relation_type, inverse_relations, relation_initializer, [embedding_size]
         )
         assert (
             self.entity_embedding.shape[-1]
@@ -468,6 +474,7 @@ class PairRE(DistanceBasedScoreFunction):
             init_KGE_uniform
         ],
         normalize_entities: bool = True,
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize PairRE model.
@@ -489,6 +496,8 @@ class PairRE(DistanceBasedScoreFunction):
         :param normalize_entities:
             If True, L2-normalize head and tail entity embeddings before projecting,
             as in :cite:p:`PairRE`. Default: True.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(PairRE, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -505,7 +514,10 @@ class PairRE(DistanceBasedScoreFunction):
         # self.relation_embedding[..., :embedding_size] : relation projection for heads
         # self.relation_embedding[..., embedding_size:] : relation projection for tails
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [embedding_size, embedding_size]
+            n_relation_type,
+            inverse_relations,
+            relation_initializer,
+            [embedding_size, embedding_size],
         )
         assert (
             2 * self.entity_embedding.shape[-1]
@@ -594,6 +606,7 @@ class TripleRE(DistanceBasedScoreFunction):
         ],
         normalize_entities: bool = True,
         u: float = 0.0,
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize TripleRE model.
@@ -618,6 +631,8 @@ class TripleRE(DistanceBasedScoreFunction):
         :param u:
             Offset factor for head/tail relation projections, as in TripleREv2.
             Default: 0.0 (no offset).
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(TripleRE, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -636,6 +651,7 @@ class TripleRE(DistanceBasedScoreFunction):
         # self.relation_embedding[..., 2*embedding_size:] : relation projection for tails
         self.relation_embedding = initialize_relation_embedding(
             n_relation_type,
+            inverse_relations,
             relation_initializer,
             [embedding_size, embedding_size, embedding_size],
         )
@@ -737,6 +753,7 @@ class DistMult(MatrixDecompositionScoreFunction):
         relation_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
             init_KGE_uniform
         ],
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize DistMult model.
@@ -753,6 +770,8 @@ class DistMult(MatrixDecompositionScoreFunction):
             Initialization function or table for entity embeddings.
         :param relation_initializer:
             Initialization function or table for relation embeddings.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(DistMult, self).__init__(negative_sample_sharing=negative_sample_sharing)
 
@@ -762,7 +781,7 @@ class DistMult(MatrixDecompositionScoreFunction):
             self.sharding, entity_initializer, [embedding_size]
         )
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [embedding_size]
+            n_relation_type, inverse_relations, relation_initializer, [embedding_size]
         )
         assert (
             self.entity_embedding.shape[-1]
@@ -828,6 +847,7 @@ class ComplEx(MatrixDecompositionScoreFunction):
         relation_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
             init_KGE_normal
         ],
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize ComplEx model.
@@ -844,6 +864,8 @@ class ComplEx(MatrixDecompositionScoreFunction):
             Initialization function or table for entity embeddings.
         :param relation_initializer:
             Initialization function or table for relation embeddings.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(ComplEx, self).__init__(negative_sample_sharing=negative_sample_sharing)
 
@@ -857,7 +879,10 @@ class ComplEx(MatrixDecompositionScoreFunction):
         # self.relation_embedding[..., :embedding_size] : real part
         # self.relation_embedding[..., embedding_size:] : imaginary part
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [2 * embedding_size]
+            n_relation_type,
+            inverse_relations,
+            relation_initializer,
+            [2 * embedding_size],
         )
         assert (
             self.entity_embedding.shape[-1]
@@ -936,6 +961,7 @@ class BoxE(DistanceBasedScoreFunction):
         apply_tanh: bool = True,
         dist_func_per_dim: bool = True,
         eps: float = 1e-6,
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize BoxE model.
@@ -968,6 +994,8 @@ class BoxE(DistanceBasedScoreFunction):
         :param eps:
             Softening parameter for geometric normalization of box widths.
             Default: 1e-6.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(BoxE, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -998,6 +1026,7 @@ class BoxE(DistanceBasedScoreFunction):
         # self.relation_embedding[..., -1] tail box size
         self.relation_embedding = initialize_relation_embedding(
             n_relation_type,
+            inverse_relations,
             relation_initializer,
             [embedding_size, embedding_size, embedding_size, embedding_size, 1, 1],
         )
@@ -1197,6 +1226,7 @@ class InterHT(DistanceBasedScoreFunction):
         ],
         normalize_entities: bool = True,
         offset: float = 1.0,
+        inverse_relations: bool = False,
     ) -> None:
         """
         Initialize InterHT model.
@@ -1220,6 +1250,8 @@ class InterHT(DistanceBasedScoreFunction):
             auxiliary head and tail entities before multiplying. Default: True.
         :param offset:
             Offset applied to auxiliary entity embeddings. Default: 1.0.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
         """
         super(InterHT, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
@@ -1236,7 +1268,10 @@ class InterHT(DistanceBasedScoreFunction):
             self.sharding, entity_initializer, [embedding_size, embedding_size]
         )
         self.relation_embedding = initialize_relation_embedding(
-            n_relation_type, relation_initializer, [embedding_size]
+            n_relation_type,
+            inverse_relations,
+            relation_initializer,
+            [embedding_size],
         )
         assert (
             self.entity_embedding.shape[-1]

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from besskge.dataset import KGDataset
+from besskge.sharding import PartitionedTripleSet, Sharding
+
+seed = 1234
+n_entity = 501
+n_relation_type = 11
+n_shard = 5
+n_triple = 2001
+n_negative = 251
+
+np.random.seed(seed)
+
+type_offsets = np.array([0, 20, 60, 200, 341, 342])
+triples_h = np.random.randint(n_entity, size=(n_triple,))
+triples_t = np.random.randint(n_entity, size=(n_triple,))
+triples_r = np.random.randint(n_relation_type, size=(n_triple,))
+part = "test"
+triples = {part: np.stack([triples_h, triples_r, triples_t], axis=1)}
+neg_heads = {
+    part: np.random.randint(n_entity, size=(n_triple, n_negative), dtype=np.int32)
+}
+neg_tails = {part: np.random.randint(n_entity, size=(1, n_negative), dtype=np.int32)}
+
+ds = KGDataset(
+    n_entity=n_entity,
+    n_relation_type=n_relation_type,
+    entity_dict=None,
+    relation_dict=None,
+    type_offsets={str(i): o for i, o in enumerate(type_offsets)},
+    triples=triples,
+    neg_heads=neg_heads,
+    neg_tails=neg_tails,
+)
+
+
+def test_entity_sharding() -> None:
+    np.random.seed(seed)
+
+    sharding = Sharding.create(
+        n_entity,
+        n_shard,
+        seed=seed,
+        type_offsets=type_offsets,
+    )
+
+    assert_equal(sharding.n_shard, n_shard)
+    assert_equal(sharding.n_entity, n_entity)
+    assert_equal(sharding.max_entity_per_shard, np.ceil(n_entity / n_shard))
+    assert_equal(np.unique(sharding.entity_to_shard), np.arange(n_shard))
+    assert_equal(
+        np.unique(sharding.entity_to_idx), np.arange(sharding.max_entity_per_shard)
+    )
+
+    # Shard counts
+    assert_equal(sharding.shard_counts.sum(), n_entity)
+    if sharding.entity_type_counts is not None:
+        assert_equal(sharding.entity_type_counts.sum(-1), sharding.shard_counts)
+
+    # Revert sharding
+    assert_equal(
+        sharding.shard_and_idx_to_entity[
+            sharding.entity_to_shard, sharding.entity_to_idx
+        ],
+        np.arange(n_entity),
+    )
+
+
+@pytest.mark.parametrize("add_inverse_triples", [True, False])
+def test_triple_partitioning_from_dataset(add_inverse_triples: bool) -> None:
+    np.random.seed(seed)
+
+    sharding = Sharding.create(
+        n_entity,
+        n_shard,
+        seed=seed,
+        type_offsets=type_offsets,
+    )
+
+    h_triple_set = PartitionedTripleSet.create_from_dataset(
+        ds, part, sharding, "h_shard", add_inverse_triples=add_inverse_triples
+    )
+    t_triple_set = PartitionedTripleSet.create_from_dataset(
+        ds, part, sharding, "t_shard", add_inverse_triples=add_inverse_triples
+    )
+    ht_triple_set = PartitionedTripleSet.create_from_dataset(
+        ds, part, sharding, "ht_shardpair", add_inverse_triples=add_inverse_triples
+    )
+
+    for triple_set, partition_mode in zip(
+        [h_triple_set, t_triple_set, ht_triple_set],
+        ["h_shard", "t_shard", "ht_shardpair"],
+    ):
+        assert triple_set.dummy == "none"
+        n_triple_tot = 2 * n_triple if add_inverse_triples else n_triple
+        assert_equal(
+            triple_set.triple_counts.sum(),
+            n_triple_tot,
+        )
+        trip = triples[part]
+        if add_inverse_triples:
+            inv_triples = np.copy(trip[:, ::-1])
+            inv_triples[:, 1] += n_relation_type
+            trip = np.concatenate([trip, inv_triples], axis=0)
+        # Put original triples in the same order as triples_set.triples
+        triple_sorted = trip[triple_set.triple_sort_idx]
+        # Check triple partitioning respects h/t sharding
+        for h_shard in range(n_shard):
+            for t_shard in range(n_shard):
+                if partition_mode == "h_shard":
+                    triple_range_l = triple_set.triple_offsets[h_shard]
+                    triple_range_u = (
+                        n_triple_tot
+                        if h_shard == n_shard - 1
+                        else triple_set.triple_offsets[h_shard + 1]
+                    )
+                    assert np.all(
+                        sharding.entity_to_shard[
+                            triple_sorted[triple_range_l:triple_range_u, 0]
+                        ]
+                        == h_shard
+                    )
+                elif partition_mode == "t_shard":
+                    triple_range_l = triple_set.triple_offsets[t_shard]
+                    triple_range_u = (
+                        n_triple_tot
+                        if t_shard == n_shard - 1
+                        else triple_set.triple_offsets[t_shard + 1]
+                    )
+                    assert np.all(
+                        sharding.entity_to_shard[
+                            triple_sorted[triple_range_l:triple_range_u, 2]
+                        ]
+                        == t_shard
+                    )
+                else:
+                    triple_range_l = triple_set.triple_offsets.flatten()[
+                        n_shard * h_shard + t_shard
+                    ]
+                    triple_range_u = (
+                        n_triple_tot
+                        if h_shard == n_shard - 1 and t_shard == n_shard - 1
+                        else triple_set.triple_offsets.flatten()[
+                            n_shard * h_shard + t_shard + 1
+                        ]
+                    )
+                    assert np.all(
+                        sharding.entity_to_shard[
+                            triple_sorted[triple_range_l:triple_range_u, 0]
+                        ]
+                        == h_shard
+                    )
+                    assert np.all(
+                        sharding.entity_to_shard[
+                            triple_sorted[triple_range_l:triple_range_u, 2]
+                        ]
+                        == t_shard
+                    )
+
+        if ds.ht_types:
+            types = ds.ht_types[part]
+            if add_inverse_triples:
+                types = np.concatenate([types, types[:, ::-1]], axis=0)
+            types_sorted = types[triple_set.triple_sort_idx]
+            assert_equal(types_sorted, triple_set.types)
+        negative_heads = neg_heads[part]
+        if add_inverse_triples:
+            negative_heads = np.concatenate(
+                [
+                    negative_heads,
+                    np.broadcast_to(neg_tails[part], negative_heads.shape),
+                ],
+                axis=0,
+            )
+            neg_tails_sorted = np.concatenate(
+                [
+                    np.broadcast_to(neg_tails[part], neg_heads[part].shape),
+                    neg_heads[part],
+                ],
+                axis=0,
+            )[triple_set.triple_sort_idx]
+            assert_equal(neg_tails_sorted, triple_set.neg_tails)
+        else:
+            assert_equal(neg_tails[part], triple_set.neg_tails)
+        neg_heads_sorted = negative_heads[triple_set.triple_sort_idx]
+        assert_equal(neg_heads_sorted, triple_set.neg_heads)
+        # Pass from global IDs to local IDs
+        if partition_mode in ["h_shard", "ht_shardpair"]:
+            triple_sorted[:, 0] = sharding.entity_to_idx[triple_sorted[:, 0]]
+        if partition_mode in ["t_shard", "ht_shardpair"]:
+            triple_sorted[:, 2] = sharding.entity_to_idx[triple_sorted[:, 2]]
+        assert_equal(triple_sorted, triple_set.triples)
+
+    if add_inverse_triples:
+        h_triple_set_noinv = PartitionedTripleSet.create_from_dataset(
+            ds, part, sharding, "h_shard", add_inverse_triples=False
+        )
+        t_triple_set_noinv = PartitionedTripleSet.create_from_dataset(
+            ds, part, sharding, "t_shard", add_inverse_triples=False
+        )
+        ht_triple_set_noinv = PartitionedTripleSet.create_from_dataset(
+            ds, part, sharding, "ht_shardpair", add_inverse_triples=False
+        )
+
+        assert_equal(
+            ht_triple_set.triple_counts,
+            ht_triple_set_noinv.triple_counts + ht_triple_set_noinv.triple_counts.T,
+        )
+        assert_equal(
+            h_triple_set.triple_counts,
+            h_triple_set_noinv.triple_counts + t_triple_set_noinv.triple_counts,
+        )
+        assert_equal(
+            t_triple_set.triple_counts,
+            h_triple_set_noinv.triple_counts + t_triple_set_noinv.triple_counts,
+        )
+
+
+@pytest.mark.parametrize("query_mode", ["hr", "rt"])
+@pytest.mark.parametrize("negative_type", [True, False])
+def test_triple_partitioning_from_queries(query_mode: str, negative_type: bool) -> None:
+    np.random.seed(seed)
+
+    sharding = Sharding.create(
+        n_entity,
+        n_shard,
+        seed=seed,
+        type_offsets=type_offsets,
+    )
+
+    if query_mode == "hr":
+        queries = triples[part][:, :2]
+        ground_truth = triples[part][:, 2]
+        if negative_type:
+            trip = np.concatenate(
+                [
+                    queries,
+                    np.full(fill_value=type_offsets[1], shape=(queries.shape[0], 1)),
+                ],
+                axis=1,
+            )
+        else:
+            trip = np.concatenate([queries, ground_truth.reshape(-1, 1)], axis=1)
+        negatives = neg_tails[part]
+    elif query_mode == "rt":
+        queries = triples[part][:, 1:]
+        ground_truth = triples[part][:, 0]
+        if negative_type:
+            trip = np.concatenate(
+                [
+                    np.full(fill_value=type_offsets[1], shape=(queries.shape[0], 1)),
+                    queries,
+                ],
+                axis=1,
+            )
+        else:
+            trip = np.concatenate([ground_truth.reshape(-1, 1), queries], axis=1)
+        negatives = neg_heads[part]
+
+    triple_set = PartitionedTripleSet.create_from_queries(
+        ds,
+        sharding,
+        queries,
+        query_mode,
+        ground_truth if not negative_type else None,
+        negatives,
+        negative_type="1" if negative_type else None,
+    )
+
+    triple_sorted = trip[triple_set.triple_sort_idx]
+    if query_mode == "hr":
+        triple_sorted[:, 0] = sharding.entity_to_idx[triple_sorted[:, 0]]
+        assert_equal(triple_set.neg_tails, negatives)
+        assert triple_set.neg_heads is None
+    elif query_mode == "rt":
+        triple_sorted[:, 2] = sharding.entity_to_idx[triple_sorted[:, 2]]
+        assert_equal(triple_set.neg_heads, negatives[triple_set.triple_sort_idx])
+        assert triple_set.neg_tails is None
+    assert_equal(triple_sorted, triple_set.triples)


### PR DESCRIPTION
Added the option to add inverse triples when constructing a `PartitionedTripleSet` from a dataset part. After some thinking, I went with the most basic implementation (creating the inverse triples before partitioning everything into buckets): it could likely be done in a smarter way, partitioning first the "normal" triples and then deriving the partitioning of the inverse ones, but it would require different implementation based on whether `partition_mode` is "h_shard"/"t_shard" or "ht_shardpair" and it didn't seem, in the end, to save significant amounts of time (partitioning is usually quite fast already).

This required also to add an option for `inverse_relations` in the scoring functions, because when using inverse relations we need to allocate twice as many embeddings in the relation table.

I was tempted to modify one of the notebooks to showcase adding inverse triples during training, but for the datasets we use there it didn't seem to give much of a performance boost, if compared with the additional training time (i.e., if you need to duplicate the training time, it is better to train for twice the number of epochs rather than using inverse triples).

Finally, I also added unit tests for entity and triple sharding, which were missing before.