### PR TITLE
Improve Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 third_party/
 wandb/
 docs/build/
+docs/source/generated
 docs/source/api
 build/
 reports/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,11 @@ You can contribute to the development of the BESS-KGE project, even if you don't
 
 Setting up a VS Code server on [Paperspace](https://www.paperspace.com/graphcore) will allow you to tunnel into a machine with IPUs from the VS Code web editor or the desktop app. This requires minimum effort and is an excellent solution for developing and testing code directly on IPU hardware.
 
-You can launch a 6-hours session on a Paperspace machine with access to 4 IPUs for free by clicking on the button [![Run on Gradient](docs/gradient-badge.svg)](https://console.paperspace.com/github/graphcore-research/bess-kge?container=graphcore%2Fpytorch-paperspace%3A3.3.0-ubuntu-20.04-20230703&machine=Free-IPU-POD4)
+You can launch a 6-hours session on a Paperspace machine with access to 4 IPUs **for free** by clicking on the button [![Run on Gradient](docs/gradient-badge.svg)](https://console.paperspace.com/github/graphcore-research/bess-kge?container=graphcore%2Fpytorch-paperspace%3A3.3.0-ubuntu-20.04-20230703&machine=Free-IPU-POD4)
 
 Start the machine and open up a terminal from the left pane.
 
-<div align="center">
-<figure>
-  <img src="docs/source/images/Terminal1.png" height=300>
-</figure>
-</div>
+![terminal_pane](docs/source/images/Terminal1.png "height=200")
 
 In the terminal, run the command
 ```shell

--- a/README.md
+++ b/README.md
@@ -75,20 +75,7 @@ Additional variations of the distribution scheme are detailed in the [BESS-KGE u
 
 ### Modules
 
-All APIs are documented in the [BESS-KGE user guide and API documentation](https://graphcore-research.github.io/bess-kge/).
-
-| API | Functions
-| --- | --- |
-| [`besskge.dataset`](besskge/dataset.py) | Build, save and load knowledge graph datasets as collections of (h,r,t) triples.|
-| [`besskge.sharding`](besskge/sharding.py) | Shard embedding tables and triple sets for distributed execution.|
-| [`besskge.embedding`](besskge/embedding.py) | Utilities to initialize entity and relation embedding tables.|
-| [`besskge.negative_sampler`](besskge/negative_sampler.py) | Sample entities to use as corrupted heads/tails when constructing negative samples. Negative entities can be sampled randomly, based on entity type or based on the triple to corrupt.|
-| [`besskge.batch_sampler`](besskge/batch_sampler.py) | Sample batches of positive and negative triples for each processing device, according to the BESS distribution scheme.|
-| [`besskge.scoring`](besskge/scoring.py) | Functions used to score positive and negative triples for different KGE models, for example TransE, ComplEx, RotatE, DistMult.|
-| [`besskge.loss`](besskge/loss.py) | Functions used to compute the batch loss based on positive and negative scores, for example log-sigmoid loss, margin ranking loss.|
-| [`besskge.metric`](besskge/metric.py) | Functions used to compute metrics for the predictions of KGE models, for example MRR, Hits@K.|
-| [`besskge.bess`](besskge/bess.py) | PyTorch modules implementing the BESS distribution scheme for KGE training and inference on multiple IPUs. |
-| [`besskge.utils`](besskge/utils.py) | General purpose utilities.|
+All APIs are documented in the [BESS-KGE API documentation](https://graphcore-research.github.io/bess-kge/API_reference.html).
 
 ### Known limitations
 

--- a/besskge/batch_sampler.py
+++ b/besskge/batch_sampler.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Classes for sampling batches of positive and negative triples for each processing device,
+according to the BESS distribution scheme.
+"""
+
 import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, List, Union, cast

--- a/besskge/bess.py
+++ b/besskge/bess.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+PyTorch modules implementing the BESS distribution scheme :cite:p:`BESS`
+for KGE training and inference on multiple IPUs.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Tuple, Union, cast
 

--- a/besskge/dataset.py
+++ b/besskge/dataset.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Utilities for building and storing knowledge graph datasets
+as collections of (h,r,t) triples.
+"""
+
 import dataclasses
 import pickle
 import tarfile

--- a/besskge/embedding.py
+++ b/besskge/embedding.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Utilities for initializing and managing entity/relation embedding tables.
+"""
+
 from typing import Callable, List, Optional, Union
 
 import numpy as np
 import torch
 
 from besskge.sharding import Sharding
-
-"""
-Utilities for entity/relation embeddings.
-"""
 
 
 def init_uniform_norm(embedding_table: torch.Tensor) -> torch.Tensor:

--- a/besskge/loss.py
+++ b/besskge/loss.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Functions for computing the batch loss based on the scores of positive
+and negative samples.
+"""
+
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/besskge/metric.py
+++ b/besskge/metric.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Utilities for computing metrics to evaluate the predictions of KGE models.
+"""
+
 import re
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, cast

--- a/besskge/negative_sampler.py
+++ b/besskge/negative_sampler.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Classes for sampling entities to use as corrupted heads/tails
+when constructing negative samples.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple, Union, cast
 

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Functions for scoring positive and negative triples,
+specific to each KGE model.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Callable, List, Union, cast
 

--- a/besskge/sharding.py
+++ b/besskge/sharding.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+Sharding of embedding tables and triple sets for distributed execution.
+"""
+
 import dataclasses
 import warnings
 from pathlib import Path

--- a/besskge/utils.py
+++ b/besskge/utils.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+"""
+General purpose utilities.
+"""
+
 import torch
 
 

--- a/dev
+++ b/dev
@@ -142,7 +142,7 @@ def doc() -> None:
     """generate Sphinx documentation"""
     subprocess.call(["rm", "-r", "docs/build"])
     subprocess.call(["rm", "-r", "docs/source/api"])
-    # subprocess.call(["rm", "docs/source/besskge.rst"])
+    subprocess.call(["rm", "-r", "docs/source/generated"])
     # run(["sphinx-apidoc", "-o", "docs/source", "besskge/"])
     run(["make", "clean", "-C", "docs/"])
     run(["make", "html", "-C", "docs/"])

--- a/docs/source/API_ref/batch_sampler.rst
+++ b/docs/source/API_ref/batch_sampler.rst
@@ -1,6 +1,0 @@
-Batch samplers
-==============
-.. automodule:: besskge.batch_sampler
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/dataset.rst
+++ b/docs/source/API_ref/dataset.rst
@@ -1,7 +1,0 @@
-Knowledge graph datasets
-========================
-
-.. automodule:: besskge.dataset
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/embedding.rst
+++ b/docs/source/API_ref/embedding.rst
@@ -1,7 +1,0 @@
-Embedding utilities
-===================
-
-.. automodule:: besskge.embedding
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/loss.rst
+++ b/docs/source/API_ref/loss.rst
@@ -1,7 +1,0 @@
-Loss functions
-==============
-
-.. automodule:: besskge.loss
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/metric.rst
+++ b/docs/source/API_ref/metric.rst
@@ -1,7 +1,0 @@
-Metrics
-==============
-
-.. automodule:: besskge.metric
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/negative_sampler.rst
+++ b/docs/source/API_ref/negative_sampler.rst
@@ -1,7 +1,0 @@
-Negative samplers
-=================
-
-.. automodule:: besskge.negative_sampler
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/scoring.rst
+++ b/docs/source/API_ref/scoring.rst
@@ -1,7 +1,0 @@
-Scoring functions
-=================
-
-.. automodule:: besskge.scoring
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/sharding.rst
+++ b/docs/source/API_ref/sharding.rst
@@ -1,7 +1,0 @@
-Sharding utilities
-==================
-
-.. automodule:: besskge.sharding
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_ref/utils.rst
+++ b/docs/source/API_ref/utils.rst
@@ -1,7 +1,0 @@
-General-purpose utility functions
-=================================
-
-.. automodule:: besskge.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -3,6 +3,7 @@ BESS-KGE API Reference
 
 .. autosummary::
    :toctree: generated
+   :template: module.rst
    :recursive:
 
    besskge.dataset

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -1,0 +1,18 @@
+BESS-KGE API Reference
+======================================
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+
+   besskge.dataset
+   besskge.sharding
+   besskge.batch_sampler
+   besskge.negative_sampler
+   besskge.bess
+   besskge.scoring
+   besskge.loss
+   besskge.metric
+   besskge.embedding
+   besskge.utils
+   

--- a/docs/source/_templates/class.rst
+++ b/docs/source/_templates/class.rst
@@ -1,0 +1,11 @@
+..
+   # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+   # Copyright (c) 2007-2023 by the Sphinx team. All rights reserved.
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :inherited-members: Module

--- a/docs/source/_templates/module.rst
+++ b/docs/source/_templates/module.rst
@@ -2,12 +2,59 @@
    # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
    # Copyright (c) 2007-2023 by the Sphinx team. All rights reserved.
 
-{%- if show_headings %}
-{{- [basename, "module"] | join(' ') | e | heading }}
+{{ fullname | escape | underline}}
 
-{% endif -%}
-.. automodule:: {{ qualname }}
-{%- for option in automodule_options %}
-   :{{ option }}:
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: class.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: class.rst
+   :recursive:
+{% for item in modules %}
+   {% if "test" not in item and "docs" not in item %}
+      {{ item }}
+   {% endif %}
 {%- endfor %}
-
+{% endif %}
+{% endblock %}

--- a/docs/source/bess.rst
+++ b/docs/source/bess.rst
@@ -1,4 +1,4 @@
-BESS modules
+BESS overview
 ================
 
 When distributing the workload over :math:`n` workers (=IPUs), BESS
@@ -7,7 +7,7 @@ size, each of which is stored in a worker's memory. The
 embedding table for relation types, on the other hand, is replicated
 across workers, as it is usually much smaller.
 
-.. figure:: ../images/embedding_sharding.jpg
+.. figure:: images/embedding_sharding.jpg
    :height: 250px
    :align: center
 
@@ -23,7 +23,7 @@ a variety that is beneficial to the final embedding quality.
 
 .. _figure2:
 
-.. figure:: ../images/batch_together.jpg
+.. figure:: images/batch_together.jpg
    :width: 700px
    :align: center
 
@@ -43,7 +43,7 @@ same number of embeddings from its on-chip memory, both for positive and
 negative samples. These include the embeddings needed by the worker
 itself, and the embeddings needed by its peers.
 
-.. figure:: ../images/gather.jpg
+.. figure:: images/gather.jpg
    :width: 650px
    :align: center
 
@@ -61,7 +61,7 @@ between workers through a balanced AllToAll collective operator. Head
 embeddings remain in place, as each triple block is then scored on the
 worker where the head embedding is stored.
 
-.. figure:: ../images/alltoall.jpg
+.. figure:: images/alltoall.jpg
    :width: 650px
    :align: center
 
@@ -85,23 +85,17 @@ sent to the correct worker via a new, balanced AllToAll.
 This allows us to communicate negative **scores** instead of negative embeddings, which is cheaper, although it
 requires additional collective communications between devices.
 
-.. figure:: ../images/allgather.jpg
+.. figure:: images/allgather.jpg
    :width: 700px
    :align: center
 
    **Figure 5**. Through an AllGather collective, the head embeddings of the :math:`n^2` blocks are
    replicated on all workers. These are then scored against the corresponding negative tails stored on the worker.
 
-.. figure:: ../images/score_moving_alltoall.jpg
+.. figure:: images/score_moving_alltoall.jpg
    :width: 700px
    :align: center
 
    **Figure 6**. Using a final AllToAll (red arrows) the partial negative **scores** are put back on the worker
    where the head embeddings came from. After this, each worker has the complete set of negative scores for each
    of the :math:`n` triple blocks it is responsible for.
-
-
-.. automodule:: besskge.bess
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 project = "BESS-KGE"
 copyright = "(c) 2023 Graphcore Ltd. All rights reserved"
-author = "Alberto Cattaneo"
+author = "Alberto Cattaneo, Daniel Justus"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -35,12 +35,15 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinxcontrib.bibtex",
     "sphinx.ext.autosectionlabel",
+    "myst_parser",
 ]
 numpydoc_show_class_members = False
 todo_include_todos = True
 autosummary_generate = True
 autoclass_content = "both"
 autodoc_typehints = "both"
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
 bibtex_default_style = "alpha"
 
 bibtex_bibfiles = ["KGbib.bib"]
@@ -59,4 +62,6 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "torch": ("https://pytorch.org/docs/stable", None),
+    "rtd": ("https://docs.readthedocs.io/en/stable/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,9 +44,10 @@ autoclass_content = "both"
 autodoc_typehints = "both"
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
-bibtex_default_style = "alpha"
 
+bibtex_default_style = "alpha"
 bibtex_bibfiles = ["KGbib.bib"]
+
 templates_path = ["_templates"]
 exclude_patterns = []
 

--- a/docs/source/contrib.md
+++ b/docs/source/contrib.md
@@ -1,0 +1,4 @@
+```{include} ../../CONTRIBUTING.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -1,0 +1,2 @@
+.. include:: contrib.md
+   :parser: myst_parser.sphinx_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-BESS-KGE User Guide and API Reference
+BESS-KGE
 ======================================
 
 .. automodule:: besskge
@@ -19,6 +19,10 @@ BESS-KGE User Guide and API Reference
    This allows BESS-KGE to achieve high throughput for both training and inference.
 
    For an introduction to the different distribution schemes used by BESS-KGE, see :ref:`BESS overview`.
+
+   .. Note:: The library is still in active development: new features can be expected to be added overtime
+      and occasional bugs may occur. Feel free to open issues in the
+      `BESS-KGE github repo <https://github.com/graphcore-research/bess-kge>`_ to report any problem.  
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,31 +21,9 @@ BESS-KGE User Guide and API Reference
    For an overview of the different distribution schemes used by BESS-KGE, see :ref:`BESS modules`.
 
 .. toctree::
-   :maxdepth: 2
-   :caption: API reference
-   :name: API_ref
+   :maxdepth: 3
+   :caption: Contents
 
-   API_ref/dataset
-   API_ref/sharding
-   API_ref/batch_sampler
-   API_ref/negative_sampler
-   API_ref/bess
-   API_ref/scoring
-   API_ref/loss
-   API_ref/metric
-   API_ref/embedding
-   API_ref/utils
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Bibliography
-   :name: Bibliography
-
-   bibliography
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   Developer guide <dev_guide>
+   API reference <API_reference>
+   Bibliography <bibliography>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,12 +18,14 @@ BESS-KGE User Guide and API Reference
 
    This allows BESS-KGE to achieve high throughput for both training and inference.
 
-   For an overview of the different distribution schemes used by BESS-KGE, see :ref:`BESS modules`.
+   For an introduction to the different distribution schemes used by BESS-KGE, see :ref:`BESS overview`.
 
 .. toctree::
    :maxdepth: 3
    :caption: Contents
 
-   Developer guide <dev_guide>
+   User guide <user_guide>
+   BESS overview <bess>
    API reference <API_reference>
+   Developers guide <dev_guide>
    Bibliography <bibliography>

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,82 @@
+User guide
+================
+
+Installation and usage
+------------------------
+
+1. Install the Poplar SDK following the instructions in the
+`Getting Started guide for your IPU system <https://docs.graphcore.ai/en/latest/getting-started.html#getting-started>`_.
+
+2. Enable the Poplar SDK, create and activate a Python :code:`virtualenv` and install the PopTorch wheel:
+
+.. code-block::
+
+    source <path to Poplar installation>/enable.sh
+    source <path to PopART installation>/enable.sh
+    python3.8 -m venv .venv
+    source .venv/bin/activate
+    pip install wheel
+    pip install $POPLAR_SDK_ENABLED/../poptorch-*.whl
+
+
+More details are given in the
+`PyTorch quick start guide <https://docs.graphcore.ai/projects/pytorch-quick-start>`_.
+
+3. Pip install BESS-KGE:
+
+.. code-block::
+
+    pip install git+https://github.com/graphcore-research/bess-kge.git
+
+4. Import and use:
+
+.. code-block::
+
+    import besskge
+
+.. Note:: The library has been tested on Poplar SDK 3.3.0+1403, Ubuntu 20.04, Python 3.8.
+
+
+Getting started
+------------------------
+
+For a walkthrough of the main :code:`besskge` library functionalities, see our Jupyter notebooks.
+We recommend the following sequence:
+
+1. `KGE training and inference on the OGBL-BioKG dataset <https://github.com/graphcore-research/bess-kge/tree/main/notebooks/1_biokg_training_inference.ipynb>`_.
+2. `Link prediction on the YAGO3-10 dataset <https://github.com/graphcore-research/bess-kge/tree/main/notebooks/2_yago_topk_prediction.ipynb>`_.
+3. `FP16 weights and compute on the OGBL-WikiKG2 dataset <https://github.com/graphcore-research/bess-kge/tree/main/notebooks/3_wikikg2_fp16.ipynb>`_.
+
+.. |run_on_gradient| image:: ../gradient-badge.svg 
+
+Click on the |run_on_gradient| button inside the notebooks to run them **for free** on physical IPUs
+available on `Paperspace <https://www.paperspace.com/graphcore>`_.
+
+Limitations
+------------------------
+
+* :code:`besskge` supports distribution for up to 16 IPUs.
+* Storing embeddings in SRAM introduces limitations on the size of the embedding tables,
+  and therefore on the entity count in the knowledge graph. Some (approximate) estimates for these limitations
+  are given in the table below (assuming FP16 for weights and FP32 for gradient accumulation and second order momentum).
+  Notice that the cap will also depend on the batch size and the number of negative samples used.
+
++----------------+-----------+--------------+-----------------------------+
+|   Embeddings   |           |              |   Max number of entities    |
+|                | Optimizer | Gradient     | (# embedding parameters) on |
++------+---------+           | accumulation +--------------+--------------+
+| size |  dtype  |           |              |   IPU-POD4   |   IPU-POD16  |
++------+---------+-----------+--------------+--------------+--------------+
+| 100  | float16 | SGDM      | No           | 3.2M (3.2e8) | 13M (1.3e9)  |
++------+---------+-----------+--------------+--------------+--------------+
+| 128  | float16 | Adam      | No           | 2.4M (3.0e8) | 9.9M (1.3e9) |
++------+---------+-----------+--------------+--------------+--------------+
+| 256  | float16 | SGDM      | Yes          | 900K (2.3e8) | 3.5M (9.0e8) |
++------+---------+-----------+--------------+--------------+--------------+
+| 256  | float16 | Adam      | No           | 1.2M (3.0e8) | 4.8M (1.2e9) |
++------+---------+-----------+--------------+--------------+--------------+
+| 512  | float16 | Adam      | Yes          | 375K (1.9e8) | 1.5M (7.7e8) |
++------+---------+-----------+--------------+--------------+--------------+
+
+If you get an error message during compilation about the ONNX protobuffer exceeding the maximum size,
+we recommend saving weights to a file using the :code:`poptorch.Options` API :code:`options._Popart.set("saveInitializersToFile", "my_file.onnx")`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ sphinx_rtd_theme==1.2.0
 sphinx_autodoc_typehints==1.22
 sphinx-automodapi==0.15.0
 sphinxcontrib-bibtex==2.5.0
+myst-parser==1.0.0


### PR DESCRIPTION
Re-styling of the Read the Docs sphinx documentation, to make it prettier and more useful to users.
Added user guide and developers guide pages and improved API references, dividing by modules (and with dedicated pages for each class/function).

(To browse the new version before merging you can run `./dev doc` from this branch and then go live from `docs/build/html/index.html`)