### PR TITLE
Adding TranS model to `scoring.py`

### DIFF
--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1479,54 +1479,54 @@ class TranS(DistanceBasedScoreFunction):
         return -self.reduce_embedding(R_h - R_t + R_r)
 
 
-    # # docstr-coverage: inherited
-    # def score_heads(
-    #     self,
-    #     head_emb: torch.Tensor,
-    #     relation_id: torch.Tensor,
-    #     tail_emb: torch.Tensor,
-    # ) -> torch.Tensor:
-    #     relation_emb = torch.index_select(
-    #         self.relation_embedding, index=relation_id, dim=0
-    #     )
-    #     head_emb_main, head_emb_aux = torch.split(head_emb, self.embedding_size, dim=-1)
-    #     tail_emb_main, tail_emb_aux = torch.split(tail_emb, self.embedding_size, dim=-1)
-    #     if self.normalize:
-    #         head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
-    #         tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
-    #         head_emb_aux = torch.nn.functional.normalize(head_emb_aux, p=2, dim=-1)
-    #         tail_emb_aux = torch.nn.functional.normalize(tail_emb_aux, p=2, dim=-1)
-    #     if self.negative_sample_sharing:
-    #         head_emb_main = head_emb_main.view(1, -1, self.embedding_size)
-    #         head_emb_aux = head_emb_aux.view(1, -1, self.embedding_size)
-    #     return -self.reduce_embedding(
-    #         head_emb_main * (tail_emb_aux + self.offset).unsqueeze(1)
-    #         + relation_emb.unsqueeze(1)
-    #         - tail_emb_main.unsqueeze(1) * (head_emb_aux + self.offset)
-    #     )
+    # docstr-coverage: inherited
+    def score_heads(
+        self,
+        head_emb: torch.Tensor,
+        relation_id: torch.Tensor,
+        tail_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        relation_emb = torch.index_select(
+            self.relation_embedding, index=relation_id, dim=0
+        )
+        r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
+        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        if self.normalize:
+            head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
+            tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
+            head_emb_tilde = torch.nn.functional.normalize(head_emb_tilde, p=2, dim=-1)
+            tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
+        if self.negative_sample_sharing:
+            head_emb_main = head_emb_main.view(1, -1, self.embedding_size)
+            head_emb_tilde = head_emb_tilde.view(1, -1, self.embedding_size)
+        R_h = head_emb_main * (tail_emb_tilde + self.offset).unsqueeze(1)
+        R_t = tail_emb_main.unsqueeze(1) * (head_emb_tilde + self.offset)
+        R_r = r_bar.unsqueeze(1) * head_emb_main + r.unsqueeze(1) + r_hat.unsqueeze(1) * tail_emb_main.unsqueeze(1)
+        return -self.reduce_embedding(R_h - R_t + R_r)
 
-    # # docstr-coverage: inherited
-    # def score_tails(
-    #     self,
-    #     head_emb: torch.Tensor,
-    #     relation_id: torch.Tensor,
-    #     tail_emb: torch.Tensor,
-    # ) -> torch.Tensor:
-    #     relation_emb = torch.index_select(
-    #         self.relation_embedding, index=relation_id, dim=0
-    #     )
-    #     head_emb_main, head_emb_aux = torch.split(head_emb, self.embedding_size, dim=-1)
-    #     tail_emb_main, tail_emb_aux = torch.split(tail_emb, self.embedding_size, dim=-1)
-    #     if self.normalize:
-    #         head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
-    #         tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
-    #         head_emb_aux = torch.nn.functional.normalize(head_emb_aux, p=2, dim=-1)
-    #         tail_emb_aux = torch.nn.functional.normalize(tail_emb_aux, p=2, dim=-1)
-    #     if self.negative_sample_sharing:
-    #         tail_emb_main = tail_emb_main.view(1, -1, self.embedding_size)
-    #         tail_emb_aux = tail_emb_aux.view(1, -1, self.embedding_size)
-    #     return -self.reduce_embedding(
-    #         head_emb_main.unsqueeze(1) * (tail_emb_aux + self.offset)
-    #         + relation_emb.unsqueeze(1)
-    #         - tail_emb_main * (head_emb_aux + self.offset).unsqueeze(1)
-    #     )
+    # docstr-coverage: inherited
+    def score_tails(
+        self,
+        head_emb: torch.Tensor,
+        relation_id: torch.Tensor,
+        tail_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        relation_emb = torch.index_select(
+            self.relation_embedding, index=relation_id, dim=0
+        )
+        r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
+        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        if self.normalize:
+            head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
+            tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
+            head_emb_tilde = torch.nn.functional.normalize(head_emb_tilde, p=2, dim=-1)
+            tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
+        if self.negative_sample_sharing:
+            tail_emb_main = tail_emb_main.view(1, -1, self.embedding_size)
+            tail_emb_tilde = tail_emb_tilde.view(1, -1, self.embedding_size)
+        R_h = head_emb_main.unsqueeze(1) * (tail_emb_tilde + self.offset)
+        R_t = tail_emb_main * (head_emb_tilde + self.offset).unsqueeze(1)
+        R_r = r_bar.unsqueeze(1) * head_emb_main.unsqueeze(1) + r.unsqueeze(1) + r_hat.unsqueeze(1) * tail_emb_main
+        return -self.reduce_embedding(R_h - R_t + R_r)

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1546,4 +1546,3 @@ class TranS(DistanceBasedScoreFunction):
             - tail_emb_main * (head_emb_tilde + self.offset - r_hat).unsqueeze(1)
             + r.unsqueeze(1)
         )
-        

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1373,6 +1373,10 @@ class InterHT(DistanceBasedScoreFunction):
 class TranS(DistanceBasedScoreFunction):
     """
     TranS scoring function :cite:p:`TranS`.
+
+    .. math::
+
+        \textbf{e}_h + \textbf{e}_r \approx \textbf{e}_t
     """
 
     def __init__(
@@ -1392,31 +1396,31 @@ class TranS(DistanceBasedScoreFunction):
         offset: float = 1.0,
         inverse_relations: bool = False,
     ) -> None:
-        # """
-        # Initialize TranS model.
+        """
+        Initialize TranS model.
 
-        # :param negative_sample_sharing:
-        #     see :meth:`DistanceBasedScoreFunction.__init__`
-        # :param scoring_norm:
-        #     see :meth:`DistanceBasedScoreFunction.__init__`
-        # :param sharding:
-        #     Entity sharding.
-        # :param n_relation_type:
-        #     Number of relation types in the knowledge graph.
-        # :param embedding_size:
-        #     Size of entity and relation embeddings.
-        # :param entity_initializer:
-        #     Initialization function or table for entity embeddings.
-        # :param relation_initializer:
-        #     Initialization function or table for relation embeddings.
-        # :param normalize_entities:
-        #     If True, L2-normalize embeddings of head and tail entities as well as
-        #     auxiliary head and tail entities before multiplying. Default: True.
-        # :param offset:
-        #     Offset applied to auxiliary entity embeddings. Default: 1.0.
-        # :param inverse_relations:
-        #     If True, learn embeddings for inverse relations. Default: False
-        # """
+        :param negative_sample_sharing:
+            see :meth:`DistanceBasedScoreFunction.__init__`
+        :param scoring_norm:
+            see :meth:`DistanceBasedScoreFunction.__init__`
+        :param sharding:
+            Entity sharding.
+        :param n_relation_type:
+            Number of relation types in the knowledge graph.
+        :param embedding_size:
+            Size of entity and relation embeddings.
+        :param entity_initializer:
+            Initialization function or table for entity embeddings.
+        :param relation_initializer:
+            Initialization function or table for relation embeddings.
+        :param normalize_entities:
+            If True, L2-normalize embeddings of head and tail entities as well as
+            tilde head and tail entities before multiplying. Default: True.
+        :param offset:
+            Offset applied to tilde entity embeddings. Default: 1.0.
+        :param inverse_relations:
+            If True, learn embeddings for inverse relations. Default: False
+        """
         super(TranS, self).__init__(
             negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
         )

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1473,10 +1473,7 @@ class TranS(DistanceBasedScoreFunction):
             tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
             head_emb_tilde = torch.nn.functional.normalize(head_emb_tilde, p=2, dim=-1)
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
-        R_h = head_emb_main * (tail_emb_tilde + self.offset)
-        R_t = tail_emb_main * (head_emb_tilde + self.offset)
-        R_r = r_bar * head_emb_main + r + r_hat * tail_emb_main
-        return -self.reduce_embedding(R_h - R_t + R_r)
+        return -self.reduce_embedding(head_emb_main * (tail_emb_tilde + self.offset + r_bar) - tail_emb_main * (head_emb_tilde + self.offset - r_hat) + r)
 
 
     # docstr-coverage: inherited
@@ -1499,11 +1496,8 @@ class TranS(DistanceBasedScoreFunction):
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
         if self.negative_sample_sharing:
             head_emb_main = head_emb_main.view(1, -1, self.embedding_size)
-            head_emb_tilde = head_emb_tilde.view(1, -1, self.embedding_size)
-        R_h = head_emb_main * (tail_emb_tilde + self.offset).unsqueeze(1)
-        R_t = tail_emb_main.unsqueeze(1) * (head_emb_tilde + self.offset)
-        R_r = r_bar.unsqueeze(1) * head_emb_main + r.unsqueeze(1) + r_hat.unsqueeze(1) * tail_emb_main.unsqueeze(1)
-        return -self.reduce_embedding(R_h - R_t + R_r)
+            head_emb_tilde = head_emb_tilde.view(1, -1, self.embedding_size)     
+        return -self.reduce_embedding(head_emb_main * (tail_emb_tilde + self.offset + r_bar).unsqueeze(1) - tail_emb_main.unsqueeze(1) * (head_emb_tilde + self.offset - r_hat.unsqueeze(1)) + r.unsqueeze(1))
 
     # docstr-coverage: inherited
     def score_tails(
@@ -1525,8 +1519,5 @@ class TranS(DistanceBasedScoreFunction):
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
         if self.negative_sample_sharing:
             tail_emb_main = tail_emb_main.view(1, -1, self.embedding_size)
-            tail_emb_tilde = tail_emb_tilde.view(1, -1, self.embedding_size)
-        R_h = head_emb_main.unsqueeze(1) * (tail_emb_tilde + self.offset)
-        R_t = tail_emb_main * (head_emb_tilde + self.offset).unsqueeze(1)
-        R_r = r_bar.unsqueeze(1) * head_emb_main.unsqueeze(1) + r.unsqueeze(1) + r_hat.unsqueeze(1) * tail_emb_main
-        return -self.reduce_embedding(R_h - R_t + R_r)
+            tail_emb_tilde = tail_emb_tilde.view(1, -1, self.embedding_size)        
+        return -self.reduce_embedding(head_emb_main.unsqueeze(1) * (tail_emb_tilde + self.offset + r_bar.unsqueeze(1)) - tail_emb_main * (head_emb_tilde + self.offset - r_hat).unsqueeze(1) + r.unsqueeze(1))

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1434,8 +1434,8 @@ class TranS(DistanceBasedScoreFunction):
         if isinstance(relation_initializer, list):
             relation_initializer = 3 * relation_initializer
         # self.relation_embedding[..., :embedding_size] : relation embedding
-        # self.relation_embedding[..., :embedding_size] : bar relation embedding
-        # self.relation_embedding[..., :embedding_size] : hat relation embedding
+        # self.relation_embedding[..., embedding_size:2*embedding_size] : bar relation embedding
+        # self.relation_embedding[..., 2*embedding_size:] : hat relation embedding
         self.relation_embedding = initialize_relation_embedding(
             n_relation_type,
             inverse_relations,
@@ -1447,7 +1447,7 @@ class TranS(DistanceBasedScoreFunction):
             == self.relation_embedding.shape[-1] / 3
             == embedding_size
         ), (
-            "Trans requires `2*embedding_size` embedding parameters for each entity"
+            "TranS requires `2*embedding_size` embedding parameters for each entity"
             " and `3*embedding_size` embedding parameters for each relation"
         )
         self.embedding_size = embedding_size

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1368,3 +1368,165 @@ class InterHT(DistanceBasedScoreFunction):
             + relation_emb.unsqueeze(1)
             - tail_emb_main * (head_emb_aux + self.offset).unsqueeze(1)
         )
+
+
+class TranS(DistanceBasedScoreFunction):
+    """
+    TranS scoring function :cite:p:`TranS`.
+    """
+
+    def __init__(
+        self,
+        negative_sample_sharing: bool,
+        scoring_norm: int,
+        sharding: Sharding,
+        n_relation_type: int,
+        embedding_size: int,
+        entity_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
+            init_KGE_uniform
+        ],
+        relation_initializer: Union[torch.Tensor, List[Callable[..., torch.Tensor]]] = [
+            init_KGE_uniform
+        ],
+        normalize_entities: bool = True,
+        offset: float = 1.0,
+        inverse_relations: bool = False,
+    ) -> None:
+        # """
+        # Initialize TranS model.
+
+        # :param negative_sample_sharing:
+        #     see :meth:`DistanceBasedScoreFunction.__init__`
+        # :param scoring_norm:
+        #     see :meth:`DistanceBasedScoreFunction.__init__`
+        # :param sharding:
+        #     Entity sharding.
+        # :param n_relation_type:
+        #     Number of relation types in the knowledge graph.
+        # :param embedding_size:
+        #     Size of entity and relation embeddings.
+        # :param entity_initializer:
+        #     Initialization function or table for entity embeddings.
+        # :param relation_initializer:
+        #     Initialization function or table for relation embeddings.
+        # :param normalize_entities:
+        #     If True, L2-normalize embeddings of head and tail entities as well as
+        #     auxiliary head and tail entities before multiplying. Default: True.
+        # :param offset:
+        #     Offset applied to auxiliary entity embeddings. Default: 1.0.
+        # :param inverse_relations:
+        #     If True, learn embeddings for inverse relations. Default: False
+        # """
+        super(TranS, self).__init__(
+            negative_sample_sharing=negative_sample_sharing, scoring_norm=scoring_norm
+        )
+
+        self.sharding = sharding
+        self.normalize = normalize_entities
+
+        if isinstance(entity_initializer, list):
+            entity_initializer = 2 * entity_initializer
+        # self.entity_embedding[..., :embedding_size] : entity embedding
+        # self.entity_embedding[..., embedding_size:] : tilde entity embedding
+        self.entity_embedding = initialize_entity_embedding(
+            self.sharding, entity_initializer, [embedding_size, embedding_size]
+        )
+        if isinstance(relation_initializer, list):
+            relation_initializer = 3 * relation_initializer
+        # self.relation_embedding[..., :embedding_size] : relation embedding
+        # self.relation_embedding[..., :embedding_size] : bar relation embedding
+        # self.relation_embedding[..., :embedding_size] : hat relation embedding
+        self.relation_embedding = initialize_relation_embedding(
+            n_relation_type,
+            inverse_relations,
+            relation_initializer,
+            [embedding_size, embedding_size, embedding_size],
+        )
+        assert (
+            self.entity_embedding.shape[-1] / 2
+            == self.relation_embedding.shape[-1] / 3
+            == embedding_size
+        ), (
+            "Trans requires `2*embedding_size` embedding parameters for each entity"
+            " and `3*embedding_size` embedding parameters for each relation"
+        )
+        self.embedding_size = embedding_size
+        self.register_buffer(
+            "offset", torch.tensor([offset], dtype=self.entity_embedding.dtype)
+        )
+
+    # docstr-coverage: inherited
+    def score_triple(
+        self,
+        head_emb: torch.Tensor,
+        relation_id: torch.Tensor,
+        tail_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        relation_emb = torch.index_select(
+            self.relation_embedding, index=relation_id, dim=0
+        )
+        r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
+        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        if self.normalize:
+            head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
+            tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
+            head_emb_tilde = torch.nn.functional.normalize(head_emb_tilde, p=2, dim=-1)
+            tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
+        R_h = head_emb_main * (tail_emb_tilde + self.offset)
+        R_t = tail_emb_main * (head_emb_tilde + self.offset)
+        R_r = r_bar * head_emb_main + r + r_hat * tail_emb_main
+        return -self.reduce_embedding(R_h - R_t + R_r)
+
+
+    # # docstr-coverage: inherited
+    # def score_heads(
+    #     self,
+    #     head_emb: torch.Tensor,
+    #     relation_id: torch.Tensor,
+    #     tail_emb: torch.Tensor,
+    # ) -> torch.Tensor:
+    #     relation_emb = torch.index_select(
+    #         self.relation_embedding, index=relation_id, dim=0
+    #     )
+    #     head_emb_main, head_emb_aux = torch.split(head_emb, self.embedding_size, dim=-1)
+    #     tail_emb_main, tail_emb_aux = torch.split(tail_emb, self.embedding_size, dim=-1)
+    #     if self.normalize:
+    #         head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
+    #         tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
+    #         head_emb_aux = torch.nn.functional.normalize(head_emb_aux, p=2, dim=-1)
+    #         tail_emb_aux = torch.nn.functional.normalize(tail_emb_aux, p=2, dim=-1)
+    #     if self.negative_sample_sharing:
+    #         head_emb_main = head_emb_main.view(1, -1, self.embedding_size)
+    #         head_emb_aux = head_emb_aux.view(1, -1, self.embedding_size)
+    #     return -self.reduce_embedding(
+    #         head_emb_main * (tail_emb_aux + self.offset).unsqueeze(1)
+    #         + relation_emb.unsqueeze(1)
+    #         - tail_emb_main.unsqueeze(1) * (head_emb_aux + self.offset)
+    #     )
+
+    # # docstr-coverage: inherited
+    # def score_tails(
+    #     self,
+    #     head_emb: torch.Tensor,
+    #     relation_id: torch.Tensor,
+    #     tail_emb: torch.Tensor,
+    # ) -> torch.Tensor:
+    #     relation_emb = torch.index_select(
+    #         self.relation_embedding, index=relation_id, dim=0
+    #     )
+    #     head_emb_main, head_emb_aux = torch.split(head_emb, self.embedding_size, dim=-1)
+    #     tail_emb_main, tail_emb_aux = torch.split(tail_emb, self.embedding_size, dim=-1)
+    #     if self.normalize:
+    #         head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
+    #         tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
+    #         head_emb_aux = torch.nn.functional.normalize(head_emb_aux, p=2, dim=-1)
+    #         tail_emb_aux = torch.nn.functional.normalize(tail_emb_aux, p=2, dim=-1)
+    #     if self.negative_sample_sharing:
+    #         tail_emb_main = tail_emb_main.view(1, -1, self.embedding_size)
+    #         tail_emb_aux = tail_emb_aux.view(1, -1, self.embedding_size)
+    #     return -self.reduce_embedding(
+    #         head_emb_main.unsqueeze(1) * (tail_emb_aux + self.offset)
+    #         + relation_emb.unsqueeze(1)
+    #         - tail_emb_main * (head_emb_aux + self.offset).unsqueeze(1)
+    #     )

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1434,8 +1434,8 @@ class TranS(DistanceBasedScoreFunction):
         if isinstance(relation_initializer, list):
             relation_initializer = 3 * relation_initializer
         # self.relation_embedding[..., :embedding_size] : relation embedding
-        # self.relation_embedding[..., embedding_size:2*embedding_size] : bar relation embedding
-        # self.relation_embedding[..., 2*embedding_size:] : hat relation embedding
+        # self.relation_embedding[..., embedding_size:2*embedding_size] : bar r embedding
+        # self.relation_embedding[..., 2*embedding_size:] : hat r embedding
         self.relation_embedding = initialize_relation_embedding(
             n_relation_type,
             inverse_relations,
@@ -1466,15 +1466,22 @@ class TranS(DistanceBasedScoreFunction):
             self.relation_embedding, index=relation_id, dim=0
         )
         r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
-        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
-        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(
+            head_emb, self.embedding_size, dim=-1
+        )
+        tail_emb_main, tail_emb_tilde = torch.split(
+            tail_emb, self.embedding_size, dim=-1
+        )
         if self.normalize:
             head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
             tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
             head_emb_tilde = torch.nn.functional.normalize(head_emb_tilde, p=2, dim=-1)
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
-        return -self.reduce_embedding(head_emb_main * (tail_emb_tilde + self.offset + r_bar) - tail_emb_main * (head_emb_tilde + self.offset - r_hat) + r)
-
+        return -self.reduce_embedding(
+            head_emb_main * (tail_emb_tilde + self.offset + r_bar)
+            - tail_emb_main * (head_emb_tilde + self.offset - r_hat)
+            + r
+        )
 
     # docstr-coverage: inherited
     def score_heads(
@@ -1487,8 +1494,12 @@ class TranS(DistanceBasedScoreFunction):
             self.relation_embedding, index=relation_id, dim=0
         )
         r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
-        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
-        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(
+            head_emb, self.embedding_size, dim=-1
+        )
+        tail_emb_main, tail_emb_tilde = torch.split(
+            tail_emb, self.embedding_size, dim=-1
+        )
         if self.normalize:
             head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
             tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
@@ -1496,8 +1507,13 @@ class TranS(DistanceBasedScoreFunction):
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
         if self.negative_sample_sharing:
             head_emb_main = head_emb_main.view(1, -1, self.embedding_size)
-            head_emb_tilde = head_emb_tilde.view(1, -1, self.embedding_size)     
-        return -self.reduce_embedding(head_emb_main * (tail_emb_tilde + self.offset + r_bar).unsqueeze(1) - tail_emb_main.unsqueeze(1) * (head_emb_tilde + self.offset - r_hat.unsqueeze(1)) + r.unsqueeze(1))
+            head_emb_tilde = head_emb_tilde.view(1, -1, self.embedding_size)
+        return -self.reduce_embedding(
+            head_emb_main * (tail_emb_tilde + self.offset + r_bar).unsqueeze(1)
+            - tail_emb_main.unsqueeze(1)
+            * (head_emb_tilde + self.offset - r_hat.unsqueeze(1))
+            + r.unsqueeze(1)
+        )
 
     # docstr-coverage: inherited
     def score_tails(
@@ -1510,8 +1526,12 @@ class TranS(DistanceBasedScoreFunction):
             self.relation_embedding, index=relation_id, dim=0
         )
         r, r_bar, r_hat = torch.split(relation_emb, self.embedding_size, dim=-1)
-        head_emb_main, head_emb_tilde = torch.split(head_emb, self.embedding_size, dim=-1)
-        tail_emb_main, tail_emb_tilde = torch.split(tail_emb, self.embedding_size, dim=-1)
+        head_emb_main, head_emb_tilde = torch.split(
+            head_emb, self.embedding_size, dim=-1
+        )
+        tail_emb_main, tail_emb_tilde = torch.split(
+            tail_emb, self.embedding_size, dim=-1
+        )
         if self.normalize:
             head_emb_main = torch.nn.functional.normalize(head_emb_main, p=2, dim=-1)
             tail_emb_main = torch.nn.functional.normalize(tail_emb_main, p=2, dim=-1)
@@ -1519,5 +1539,11 @@ class TranS(DistanceBasedScoreFunction):
             tail_emb_tilde = torch.nn.functional.normalize(tail_emb_tilde, p=2, dim=-1)
         if self.negative_sample_sharing:
             tail_emb_main = tail_emb_main.view(1, -1, self.embedding_size)
-            tail_emb_tilde = tail_emb_tilde.view(1, -1, self.embedding_size)        
-        return -self.reduce_embedding(head_emb_main.unsqueeze(1) * (tail_emb_tilde + self.offset + r_bar.unsqueeze(1)) - tail_emb_main * (head_emb_tilde + self.offset - r_hat).unsqueeze(1) + r.unsqueeze(1))
+            tail_emb_tilde = tail_emb_tilde.view(1, -1, self.embedding_size)
+        return -self.reduce_embedding(
+            head_emb_main.unsqueeze(1)
+            * (tail_emb_tilde + self.offset + r_bar.unsqueeze(1))
+            - tail_emb_main * (head_emb_tilde + self.offset - r_hat).unsqueeze(1)
+            + r.unsqueeze(1)
+        )
+        

--- a/besskge/scoring.py
+++ b/besskge/scoring.py
@@ -1373,10 +1373,6 @@ class InterHT(DistanceBasedScoreFunction):
 class TranS(DistanceBasedScoreFunction):
     """
     TranS scoring function :cite:p:`TranS`.
-
-    .. math::
-
-        \textbf{e}_h + \textbf{e}_r \approx \textbf{e}_t
     """
 
     def __init__(

--- a/docs/source/KGbib.bib
+++ b/docs/source/KGbib.bib
@@ -186,7 +186,7 @@
 }
 
 @inproceedings{TranS,
-  title		={TranS: Transition-based Knowledge Graph Embedding with Synthetic Relation Representation},
+  title		={{TranS: Transition-based Knowledge Graph Embedding with Synthetic Relation Representation}},
   author	={Zhang, Xuanyu and Yang, Qing and Xu, Dongliang},
   booktitle	={Findings of the Association for Computational Linguistics: EMNLP 2022},
   pages		={1202--1208},

--- a/docs/source/KGbib.bib
+++ b/docs/source/KGbib.bib
@@ -184,3 +184,11 @@
   journal   = {arXiv preprint arXiv:2202.04897},
   year      = {2022}
 }
+
+@inproceedings{TranS,
+  title		={TranS: Transition-based Knowledge Graph Embedding with Synthetic Relation Representation},
+  author	={Zhang, Xuanyu and Yang, Qing and Xu, Dongliang},
+  booktitle	={Findings of the Association for Computational Linguistics: EMNLP 2022},
+  pages		={1202--1208},
+  year		={2022}
+}


### PR DESCRIPTION
Here we have added the TranS model to the BESS library. 

Link to the TranS paper: https://aclanthology.org/2022.findings-emnlp.86.pdf