### PR TITLE
AllScoresBESS and high-level pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     container: graphcore/pytorch:3.3.0-ubuntu-20.04-20230703
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
     - uses: actions/checkout@v3
     - name: Install dev-requirements

--- a/besskge/__init__.py
+++ b/besskge/__init__.py
@@ -45,6 +45,7 @@ from . import (  # NOQA:F401,E402
     loss,
     metric,
     negative_sampler,
+    pipeline,
     scoring,
     sharding,
     utils,

--- a/besskge/pipeline.py
+++ b/besskge/pipeline.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+"""
+High-level APIs for training/inference with BESS.
+"""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+import poptorch
+import torch
+from tqdm import tqdm
+
+from besskge.batch_sampler import ShardedBatchSampler
+from besskge.bess import AllScoresBESS
+from besskge.metric import Evaluation
+from besskge.negative_sampler import PlaceholderNegativeSampler
+from besskge.scoring import BaseScoreFunction
+
+
+class AllScoresPipeline(torch.nn.Module):
+    """
+    Pipeline to compute scores of (h, r, ?) / (?, r, t)
+    queries against all entities in the KG, and related
+    prediction metrics.
+
+    To be used in combination with a batch sampler based on a
+    "h_shard"/"t_shard"-partitioned triple set.
+    """
+
+    def __init__(
+        self,
+        batch_sampler: ShardedBatchSampler,
+        corruption_scheme: str,
+        score_fn: BaseScoreFunction,
+        evaluation: Optional[Evaluation] = None,
+        windows_size: int = 1000,
+    ) -> None:
+        """
+        Initialize pipeline.
+
+        :param batch_sampler:
+            Batch sampler, based on a
+            "h_shard"/"t_shard"-partitioned triple set.
+        :param corruption_scheme:
+            Set to "t" to score (h, r, ?) completions, or to
+            "h" to score (?, r, t) completions.
+        :param score_fn:
+            The trained scoring function.
+        :param evaluation:
+            Evaluation module, for computing metrics.
+            Default: None.
+        :param windows_size:
+            Size of the sliding window, namely the number of negative entities
+            scored against each query at each step on IPU and returned to host.
+            Should be decreased with large batch sizes, to avoid an OOM error.
+            Default: 1000.
+        """
+        super().__init__()
+        self.batch_sampler = batch_sampler
+        if corruption_scheme not in ["h", "t"]:
+            raise ValueError("corruption_scheme needs to be either 'h' or 't'")
+        if (
+            corruption_scheme == "h"
+            and self.batch_sampler.triple_partition_mode != "t_shard"
+        ):
+            raise ValueError(
+                "Corruption scheme 'h' requires 't-shard'-partitioned triples"
+            )
+        elif (
+            corruption_scheme == "t"
+            and self.batch_sampler.triple_partition_mode != "h_shard"
+        ):
+            raise ValueError(
+                "Corruption scheme 't' requires 'h-shard'-partitioned triples"
+            )
+        self.candidate_sampler = PlaceholderNegativeSampler(
+            corruption_scheme=corruption_scheme
+        )
+        self.score_fn = score_fn
+        self.evaluation = evaluation
+        self.window_size = windows_size
+        self.bess_module = AllScoresBESS(
+            self.candidate_sampler, self.score_fn, self.window_size
+        )
+
+        inf_options = poptorch.Options()
+        inf_options.replication_factor = self.bess_module.sharding.n_shard
+        inf_options.deviceIterations(self.batch_sampler.batches_per_step)
+        inf_options.outputMode(poptorch.OutputMode.All)
+        self.dl = self.batch_sampler.get_dataloader(options=inf_options, shuffle=False)
+
+        self.poptorch_module = poptorch.inferenceModel(
+            self.bess_module, options=inf_options
+        )
+        self.poptorch_module.entity_embedding.replicaGrouping(
+            poptorch.CommGroupType.NoGrouping,
+            0,
+            poptorch.VariableRetrievalMode.OnePerGroup,
+        )
+
+    def forward(self) -> Dict[str, Any]:
+        """
+        Compute scores of all completions and (possibly) metrics.
+
+        :return:
+            Scores, metrics, and (if provided in batch sampler) IDs
+            of inference triples (wrt partitioned_triple_set.triples)
+            to order results.
+        """
+        scores = []
+        ids = []
+        metrics = []
+        ranks = []
+        n_triple = 0
+        for batch in tqdm(iter(self.dl)):
+            triple_mask = batch.pop("triple_mask")
+            if (
+                self.candidate_sampler.corruption_scheme == "h"
+                and "head" in batch.keys()
+            ):
+                ground_truth = batch.pop("head")
+            elif (
+                self.candidate_sampler.corruption_scheme == "t"
+                and "tail" in batch.keys()
+            ):
+                ground_truth = batch.pop("tail")
+            if self.batch_sampler.return_triple_idx:
+                triple_id = batch.pop("triple_idx")
+                ids.append(triple_id[triple_mask])
+            n_triple += triple_mask.sum()
+
+            batch_res = []
+            batch_idx = []
+            for i in range(self.bess_module.n_step):
+                step = (
+                    torch.tensor([i], dtype=torch.int32)
+                    .broadcast_to(
+                        (
+                            self.bess_module.sharding.n_shard
+                            * self.batch_sampler.batches_per_step,
+                            1,
+                        )
+                    )
+                    .contiguous()
+                )
+                ent_slice = torch.minimum(
+                    i * self.bess_module.window_size
+                    + torch.arange(self.bess_module.window_size),
+                    torch.tensor(self.bess_module.sharding.max_entity_per_shard - 1),
+                )
+                # Global indices of entities scored in the step
+                batch_idx.append(
+                    self.bess_module.sharding.shard_and_idx_to_entity[
+                        :, ent_slice
+                    ].flatten()
+                )
+                inp = {k: v.flatten(end_dim=1) for k, v in batch.items()}
+                inp.update(dict(step=step))
+                batch_res.append(self.poptorch_module(**inp))
+            batch_scores = torch.concat(batch_res, dim=-1)
+            # Filter out padding scores
+            batch_scores_filt = batch_scores[triple_mask.flatten()][
+                :, np.unique(np.concatenate(batch_idx), return_index=True)[1]
+            ][:, : self.bess_module.sharding.n_entity]
+            scores.append(torch.clone(batch_scores_filt))
+
+            if self.evaluation:
+                assert (
+                    ground_truth is not None
+                ), "Evaluation requires providing ground truth entities"
+                # Scores of true triples
+                true_scores = batch_scores_filt[
+                    torch.arange(batch_scores_filt.shape[0]),
+                    ground_truth[triple_mask],
+                ]
+                # Mask scores of true triples to compute ranks
+                batch_scores_filt[
+                    torch.arange(batch_scores_filt.shape[0]),
+                    ground_truth[triple_mask],
+                ] = -torch.inf
+                batch_ranks = self.evaluation.ranks_from_scores(
+                    true_scores, batch_scores_filt
+                )
+                metrics.append(self.evaluation.dict_metrics_from_ranks(batch_ranks))
+                if self.evaluation.return_ranks:
+                    ranks.append(batch_ranks)
+
+        out = dict(scores=torch.concat(scores, dim=0))
+        if ids:
+            out["triple_ids"] = torch.concat(ids, dim=0)
+        if self.evaluation:
+            concat_metrics = dict()
+            for m in metrics[0].keys():
+                concat_metrics[m] = torch.concat(
+                    [met[m].reshape(-1) for met in metrics]
+                )
+            out["metrics"] = concat_metrics  # type: ignore
+            # Average metrics over all triples
+            out["metrics_avg"] = {
+                m: v.sum() / n_triple for m, v in concat_metrics.items()
+            }  # type: ignore
+            if ranks:
+                out["ranks"] = torch.concat(ranks, dim=0)
+
+        return out

--- a/besskge/pipeline.py
+++ b/besskge/pipeline.py
@@ -69,7 +69,7 @@ class AllScoresPipeline(torch.nn.Module):
         self.batch_sampler = batch_sampler
         if not (evaluation or return_scores):
             raise ValueError(
-                "Nothing to return. Provide `evaluation` or set" " `return_scores=True`"
+                "Nothing to return. Provide `evaluation` or set `return_scores=True`"
             )
         if corruption_scheme not in ["h", "t"]:
             raise ValueError("corruption_scheme needs to be either 'h' or 't'")

--- a/besskge/pipeline.py
+++ b/besskge/pipeline.py
@@ -41,7 +41,7 @@ class AllScoresPipeline(torch.nn.Module):
         return_scores: bool = False,
         return_topk: bool = False,
         k: int = 10,
-        windows_size: int = 1000,
+        window_size: int = 1000,
         use_ipu_model: bool = False,
     ) -> None:
         """
@@ -75,7 +75,7 @@ class AllScoresPipeline(torch.nn.Module):
         :param k:
             If `return_topk` is set to True, for each query return the
             top-k most likely predictions (after filtering). Default: 10.
-        :param windows_size:
+        :param window_size:
             Size of the sliding window, namely the number of negative entities
             scored against each query at each step on IPU and returned to host.
             Should be decreased with large batch sizes, to avoid an OOM error.
@@ -113,7 +113,7 @@ class AllScoresPipeline(torch.nn.Module):
         self.return_scores = return_scores
         self.return_topk = return_topk
         self.k = k
-        self.window_size = windows_size
+        self.window_size = window_size
         self.corruption_scheme = corruption_scheme
         self.bess_module = AllScoresBESS(
             self.candidate_sampler, self.score_fn, self.window_size

--- a/besskge/pipeline.py
+++ b/besskge/pipeline.py
@@ -102,7 +102,8 @@ class AllScoresPipeline(torch.nn.Module):
         inf_options.replication_factor = self.bess_module.sharding.n_shard
         inf_options.deviceIterations(self.batch_sampler.batches_per_step)
         inf_options.outputMode(poptorch.OutputMode.All)
-        inf_options.useIpuModel(use_ipu_model)
+        if use_ipu_model:
+            inf_options.useIpuModel(True)
         self.dl = self.batch_sampler.get_dataloader(options=inf_options, shuffle=False)
 
         self.poptorch_module = poptorch.inferenceModel(

--- a/besskge/pipeline.py
+++ b/besskge/pipeline.py
@@ -188,7 +188,7 @@ class AllScoresPipeline(torch.nn.Module):
 
         out = dict(scores=torch.concat(scores, dim=0))
         if ids:
-            out["triple_ids"] = torch.concat(ids, dim=0)
+            out["triple_idx"] = torch.concat(ids, dim=0)
         if self.evaluation:
             concat_metrics = dict()
             for m in metrics[0].keys():

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -6,6 +6,7 @@ BESS-KGE API Reference
    :template: module.rst
    :recursive:
 
+   besskge.pipeline
    besskge.dataset
    besskge.sharding
    besskge.batch_sampler

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ flake8==6.0.0
 isort==5.12.0
 mypy==1.0.1
 pandas-stubs==2.0.1.230501
+tqdm-stubs==0.2.1
 types-requests==2.28.11.17
 pytest==7.2.1
 pytest-cov==4.0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,10 +14,10 @@ from besskge.scoring import ComplEx
 from besskge.sharding import PartitionedTripleSet, Sharding
 
 seed = 1234
-n_entity = 20000
+n_entity = 5000
 n_relation_type = 50
 n_shard = 4
-n_test_triple = 5000
+n_test_triple = 1000
 batches_per_step = 2
 shard_bs = 400
 embedding_size = 128

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,7 +90,7 @@ def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> N
 
     # Shuffle triples in same order of out["scores"]
     triple_reordered = torch.from_numpy(
-        ds.triples["test"][partitioned_triple_set.triple_sort_idx[out["triple_ids"]]]
+        ds.triples["test"][partitioned_triple_set.triple_sort_idx[out["triple_idx"]]]
     )
 
     # Real scores

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,7 @@ from besskge.negative_sampler import PlaceholderNegativeSampler
 from besskge.pipeline import AllScoresPipeline
 from besskge.scoring import ComplEx
 from besskge.sharding import PartitionedTripleSet, Sharding
+from besskge.utils import get_entity_filter
 
 seed = 1234
 n_entity = 5000
@@ -30,15 +31,19 @@ sharding = Sharding.create(n_entity, n_shard, seed=seed)
 unsharded_entity_table = torch.randn(size=(n_entity, 2 * embedding_size))
 relation_table = torch.randn(size=(n_relation_type, 2 * embedding_size))
 
-test_triples_h = np.random.randint(n_entity, size=(n_test_triple,))
-test_triples_t = np.random.randint(n_entity, size=(n_test_triple,))
-test_triples_r = np.random.randint(n_relation_type, size=(n_test_triple,))
+test_triples_h = np.random.choice(n_entity - 1, size=n_test_triple, replace=False)
+test_triples_t = np.random.choice(n_entity - 1, size=n_test_triple, replace=False)
+test_triples_r = np.random.randint(n_relation_type, size=n_test_triple)
 triples = {"test": np.stack([test_triples_h, test_triples_r, test_triples_t], axis=1)}
 
 
 @pytest.mark.parametrize("corruption_scheme", ["h", "t"])
-@pytest.mark.parametrize("compute_metrics", [True, False])
-def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> None:
+@pytest.mark.parametrize(
+    "filter_scores, extra_only", [(True, True), (True, False), (False, False)]
+)
+def test_all_scores_pipeline(
+    corruption_scheme: str, filter_scores: bool, extra_only: bool
+) -> None:
     ds = KGDataset(
         n_entity=n_entity,
         n_relation_type=n_relation_type,
@@ -76,18 +81,28 @@ def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> N
         return_triple_idx=True,
     )
 
-    if compute_metrics:
-        evaluation = Evaluation(
-            ["mrr", "hits@10"], mode="average", reduction="sum", return_ranks=True
+    evaluation = Evaluation(
+        ["mrr", "hits@10"], mode="average", reduction="sum", return_ranks=True
+    )
+
+    ground_truth_col = 0 if corruption_scheme == "h" else 2
+    if filter_scores:
+        extra_filter_triples = np.copy(triples["test"])
+        extra_filter_triples[:, ground_truth_col] += 1
+        triples_to_filter = (
+            [extra_filter_triples]
+            if extra_only
+            else [triples["test"], extra_filter_triples]
         )
     else:
-        evaluation = None
+        triples_to_filter = None
 
     pipeline = AllScoresPipeline(
         test_bs,
         corruption_scheme,
         score_fn,
         evaluation,
+        filter_triples=triples_to_filter,  # type: ignore
         return_scores=True,
         windows_size=1000,
         use_ipu_model=True,
@@ -99,35 +114,61 @@ def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> N
         ds.triples["test"][partitioned_triple_set.triple_sort_idx[out["triple_idx"]]]
     )
 
-    # Real scores
+    # All scores, computed on CPU
     if corruption_scheme == "t":
-        real_scores = score_fn.score_tails(
+        cpu_scores = score_fn.score_tails(
             unsharded_entity_table[triple_reordered[:, 0]],
             triple_reordered[:, 1],
             unsharded_entity_table.unsqueeze(0),
         )
     else:
-        real_scores = score_fn.score_heads(
+        cpu_scores = score_fn.score_heads(
             unsharded_entity_table.unsqueeze(0),
             triple_reordered[:, 1],
             unsharded_entity_table[triple_reordered[:, 2]],
         )
 
-    assert_close(real_scores, out["scores"], atol=1e-3, rtol=1e-4)
+    pos_scores = score_fn.score_triple(
+        unsharded_entity_table[triple_reordered[:, 0]],
+        triple_reordered[:, 1],
+        unsharded_entity_table[triple_reordered[:, 2]],
+    ).flatten()
+    # mask positive scores to compute metrics
+    cpu_scores[
+        torch.arange(cpu_scores.shape[0]), triple_reordered[:, ground_truth_col]
+    ] = -torch.inf
+    if filter_scores:
+        filter_triples = torch.from_numpy(
+            np.concatenate(triples_to_filter, axis=0)  # type: ignore
+        )
+        tr_filter = get_entity_filter(
+            triple_reordered, filter_triples, corruption_scheme
+        )
+        cpu_scores[tr_filter[:, 0], tr_filter[:, 1]] = -torch.inf
+        # check filters (for convenience, here h/t entities are non-repeating)
+        if extra_only:
+            assert torch.all(tr_filter[:, 0] == torch.arange(n_test_triple))
+            assert torch.all(
+                tr_filter[:, 1] == triple_reordered[:, ground_truth_col] + 1
+            )
+        else:
+            assert torch.all(tr_filter[::2, 0] == tr_filter[1::2, 0])
+            assert torch.all(tr_filter[::2, 0] == torch.arange(n_test_triple))
+            assert torch.all(tr_filter[::2, 1] == triple_reordered[:, ground_truth_col])
+            assert torch.all(
+                tr_filter[1::2, 1] == triple_reordered[:, ground_truth_col] + 1
+            )
 
-    if evaluation:
-        ground_truth_col = 0 if corruption_scheme == "h" else 2
-        real_scores_masked = torch.clone(real_scores)
-        pos_scores = real_scores_masked[
-            torch.arange(real_scores.shape[0]), triple_reordered[:, ground_truth_col]
-        ]
-        real_scores_masked[
-            torch.arange(real_scores.shape[0]), triple_reordered[:, ground_truth_col]
-        ] = -torch.inf
+    cpu_ranks = evaluation.ranks_from_scores(pos_scores, cpu_scores)
 
-        real_ranks = evaluation.ranks_from_scores(pos_scores, real_scores_masked)
+    # we allow for a off-by-one rank difference on at most 1% of triples,
+    # due to rounding differences in CPU vs IPU score computations
+    assert torch.all(torch.abs(cpu_ranks - out["ranks"]) <= 1)
+    assert (cpu_ranks != out["ranks"]).sum() < n_test_triple / 100
 
-        # we allow for a off-by-one rank difference on at most 1% of triples,
-        # due to rounding differences in CPU vs IPU score computations
-        assert torch.all(torch.abs(real_ranks - out["ranks"]) <= 1)
-        assert (real_ranks != out["ranks"]).sum() < n_test_triple / 100
+    # restore positive scores
+    cpu_scores[
+        torch.arange(cpu_scores.shape[0]), triple_reordered[:, ground_truth_col]
+    ] = pos_scores
+
+    assert_close(cpu_scores, out["scores"], atol=1e-3, rtol=1e-4)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+import numpy as np
+import pytest
+import torch
+from torch.testing import assert_close
+
+from besskge.batch_sampler import RigidShardedBatchSampler
+from besskge.dataset import KGDataset
+from besskge.metric import Evaluation
+from besskge.negative_sampler import PlaceholderNegativeSampler
+from besskge.pipeline import AllScoresPipeline
+from besskge.scoring import ComplEx
+from besskge.sharding import PartitionedTripleSet, Sharding
+
+seed = 1234
+n_entity = 20000
+n_relation_type = 50
+n_shard = 4
+n_test_triple = 5000
+batches_per_step = 2
+shard_bs = 400
+embedding_size = 128
+
+np.random.seed(seed)
+torch.manual_seed(seed)
+
+sharding = Sharding.create(n_entity, n_shard, seed=seed)
+
+unsharded_entity_table = torch.randn(size=(n_entity, 2 * embedding_size))
+relation_table = torch.randn(size=(n_relation_type, 2 * embedding_size))
+
+test_triples_h = np.random.randint(n_entity, size=(n_test_triple,))
+test_triples_t = np.random.randint(n_entity, size=(n_test_triple,))
+test_triples_r = np.random.randint(n_relation_type, size=(n_test_triple,))
+triples = {"test": np.stack([test_triples_h, test_triples_r, test_triples_t], axis=1)}
+
+
+@pytest.mark.parametrize("corruption_scheme", ["h", "t"])
+@pytest.mark.parametrize("compute_metrics", [True, False])
+def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> None:
+    ds = KGDataset(
+        n_entity=n_entity,
+        n_relation_type=n_relation_type,
+        entity_dict=None,
+        relation_dict=None,
+        type_offsets=None,
+        triples=triples,
+    )
+
+    partition_mode = "h_shard" if corruption_scheme == "t" else "t_shard"
+    partitioned_triple_set = PartitionedTripleSet.create_from_dataset(
+        ds, "test", sharding, partition_mode=partition_mode
+    )
+
+    score_fn = ComplEx(
+        negative_sample_sharing=True,
+        sharding=sharding,
+        n_relation_type=ds.n_relation_type,
+        embedding_size=embedding_size,
+        entity_initializer=unsharded_entity_table,
+        relation_initializer=relation_table,
+    )
+    placeholder_ns = PlaceholderNegativeSampler(
+        corruption_scheme=corruption_scheme, seed=seed
+    )
+
+    test_bs = RigidShardedBatchSampler(
+        partitioned_triple_set=partitioned_triple_set,
+        negative_sampler=placeholder_ns,
+        shard_bs=shard_bs,
+        batches_per_step=batches_per_step,
+        seed=seed,
+        hrt_freq_weighting=False,
+        duplicate_batch=False,
+        return_triple_idx=True,
+    )
+
+    if compute_metrics:
+        evaluation = Evaluation(
+            ["mrr", "hits@10"], mode="average", reduction="sum", return_ranks=True
+        )
+    else:
+        evaluation = None
+
+    pipeline = AllScoresPipeline(
+        test_bs, corruption_scheme, score_fn, evaluation, windows_size=1000
+    )
+    out = pipeline()
+
+    # Shuffle triples in same order of out["scores"]
+    triple_reordered = torch.from_numpy(
+        ds.triples["test"][partitioned_triple_set.triple_sort_idx[out["triple_ids"]]]
+    )
+
+    # Real scores
+    if corruption_scheme == "t":
+        real_scores = score_fn.score_tails(
+            unsharded_entity_table[triple_reordered[:, 0]],
+            triple_reordered[:, 1],
+            unsharded_entity_table.unsqueeze(0),
+        )
+    else:
+        real_scores = score_fn.score_heads(
+            unsharded_entity_table.unsqueeze(0),
+            triple_reordered[:, 1],
+            unsharded_entity_table[triple_reordered[:, 2]],
+        )
+
+    assert_close(real_scores, out["scores"], atol=1e-3, rtol=1e-4)
+
+    if evaluation:
+        ground_truth_col = 0 if corruption_scheme == "h" else 2
+        real_scores_masked = torch.clone(real_scores)
+        pos_scores = real_scores_masked[
+            torch.arange(real_scores.shape[0]), triple_reordered[:, ground_truth_col]
+        ]
+        real_scores_masked[
+            torch.arange(real_scores.shape[0]), triple_reordered[:, ground_truth_col]
+        ] = -torch.inf
+
+        real_ranks = evaluation.ranks_from_scores(pos_scores, real_scores_masked)
+
+        # we allow for a off-by-one rank difference on at most 1% of triples,
+        # due to rounding differences in CPU vs IPU score computations
+        assert torch.all(torch.abs(real_ranks - out["ranks"]) <= 1)
+        assert (real_ranks != out["ranks"]).sum() < n_test_triple / 100

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -84,7 +84,12 @@ def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> N
         evaluation = None
 
     pipeline = AllScoresPipeline(
-        test_bs, corruption_scheme, score_fn, evaluation, windows_size=1000
+        test_bs,
+        corruption_scheme,
+        score_fn,
+        evaluation,
+        windows_size=1000,
+        use_ipu_model=True,
     )
     out = pipeline()
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -106,7 +106,7 @@ def test_all_scores_pipeline(
         return_scores=True,
         return_topk=True,
         k=10,
-        windows_size=1000,
+        window_size=1000,
         use_ipu_model=True,
     )
     out = pipeline()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,6 +88,7 @@ def test_all_scores_pipeline(corruption_scheme: str, compute_metrics: bool) -> N
         corruption_scheme,
         score_fn,
         evaluation,
+        return_scores=True,
         windows_size=1000,
         use_ipu_model=True,
     )


### PR DESCRIPTION
Added BESS class to compute and return to hosts scores of queries vs a block of entities on the IPU, allowing to compute all scores by outer loop on blocks. This outer loop is implemented in a new higher-level pipeline, for ease of use (see corresponding unit test for an example on how to use it).