### PR TITLE
Add ConvE scoring function

### DIFF
--- a/besskge/embedding.py
+++ b/besskge/embedding.py
@@ -26,6 +26,24 @@ def init_uniform_norm(embedding_table: torch.Tensor) -> torch.Tensor:
     return torch.nn.functional.normalize(torch.nn.init.uniform(embedding_table), dim=-1)
 
 
+def init_xavier_norm(embedding_table: torch.Tensor, gain: float = 1.0) -> torch.Tensor:
+    """
+    Initialize embeddings according to Xavier normal scheme, with
+    `fan_in = 0`, `fan_out=row_size`.
+
+    :param embedding_table:
+        Tensor of embedding parameters to initialize.
+    :param gain:
+        Scaling factor for standard deviation. Default: 1.0.
+
+    :return:
+        Initialized tensor.
+    """
+    return torch.nn.init.normal_(
+        embedding_table, std=gain * np.sqrt(2.0 / embedding_table.shape[-1])
+    )
+
+
 def init_KGE_uniform(
     embedding_table: torch.Tensor, b: float = 1.0, divide_by_embedding_size: bool = True
 ) -> torch.Tensor:


### PR DESCRIPTION
Paper: https://cdn.aaai.org/ojs/11573/11573-13-15101-1-2-20201228.pdf
Original implementation: https://github.com/TimDettmers/ConvE/blob/master/model.py#L79
PyKeen: https://github.com/pykeen/pykeen/blob/master/src/pykeen/models/unimodal/conv_e.py, https://github.com/pykeen/pykeen/blob/master/src/pykeen/nn/functional.py#L99

The implementation follows quite closely the PK one. It's worth noting that, by how it's defined, the role of heads and tails in the scoring function is quite asymmetrical (heads and relations are combined via convolution, and the output is then multiplied with tails). Looking at the paper, this seems to be done by design to allow for efficient 1-N scoring (i.e. broadcasted scoring) of (h,r) queries against multiple tails at once. As a matter of fact, it was rather painless to implement the `score_tails` method using the broadcasted dot product that we already had for DistMult/ComplEx. However, there is no way of doing this for `score_heads`, where we need to materialize all (bs, n_negative, emb_size) hr queries explicitly - and this is quite problematic when using negative sample sharing. I think it should only be used with "tail" corruption scheme, also because it does not seem to train correctly when adding head-corrupted triples (something that I am also seeing in PyKeen and that I am not sure I understand)...