### PR TITLE
Track original triple IDs in KGDataset.from_triples

### DIFF
--- a/besskge/dataset.py
+++ b/besskge/dataset.py
@@ -123,8 +123,9 @@ class KGDataset:
             id_shuffle, (num_train, num_train + num_valid), axis=0
         )
         triples = dict()
-        for split in ["train", "valid", "test"]:
-            triples[split] = data[triple_ids[split]]
+        triples["train"] = data[triple_ids["train"]]
+        triples["valid"] = data[triple_ids["valid"]]
+        triples["test"] = data[triple_ids["test"]]
 
         ds = cls(
             n_entity=data[:, [0, 2]].max() + 1,
@@ -134,7 +135,7 @@ class KGDataset:
             type_offsets=type_offsets,
             triples=triples,
         )
-        ds.original_triple_ids = triple_ids
+        ds.original_triple_ids = triple_ids  # type: ignore
 
         return ds
 

--- a/besskge/dataset.py
+++ b/besskge/dataset.py
@@ -36,6 +36,11 @@ class KGDataset:
     #: {part: int32[n_triple, {h,r,t}]}
     triples: Dict[str, NDArray[np.int32]]
 
+    #: IDs of the triples in KGDataset.triples wrt
+    #: the ordering in the original array/dataframe
+    #: from where the triples originate.
+    original_triple_ids: Dict[str, NDArray[np.int32]]
+
     #: Entity labels by ID; str[n_entity]
     entity_dict: Optional[List[str]] = None
 
@@ -134,8 +139,8 @@ class KGDataset:
             relation_dict=relation_dict,
             type_offsets=type_offsets,
             triples=triples,
+            original_triple_ids=triple_ids,
         )
-        ds.original_triple_ids = triple_ids  # type: ignore
 
         return ds
 
@@ -228,6 +233,9 @@ class KGDataset:
                 relation_dict=relation_dict,
                 type_offsets=type_offsets,
                 triples=triples,
+                original_triple_ids={
+                    k: np.arange(v.shape[0]) for k, v in triples.items()
+                },
             )
 
     @classmethod
@@ -289,6 +297,7 @@ class KGDataset:
             relation_dict=rel_dict,
             type_offsets=type_offsets,
             triples=triples,
+            original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
             neg_heads=neg_heads,
             neg_tails=neg_tails,
         )
@@ -338,6 +347,7 @@ class KGDataset:
             relation_dict=rel_dict,
             type_offsets=None,
             triples=triples,
+            original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
             neg_heads=neg_heads,
             neg_tails=neg_tails,
         )

--- a/tests/test_batch_sampler.py
+++ b/tests/test_batch_sampler.py
@@ -36,6 +36,7 @@ ds = KGDataset(
     relation_dict=None,
     type_offsets=None,
     triples=triples,
+    original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
     neg_heads=None,
     neg_tails=None,
 )

--- a/tests/test_bess.py
+++ b/tests/test_bess.py
@@ -79,6 +79,7 @@ def test_bess_inference(
         relation_dict=None,
         type_offsets=None,
         triples=triples,
+        original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
         neg_heads=neg_heads,
         neg_tails=neg_tails,
     )
@@ -306,6 +307,7 @@ def test_bess_topk_prediction(
         relation_dict=None,
         type_offsets=None,
         triples=triples,
+        original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
         neg_heads=neg_heads,
         neg_tails=neg_tails,
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,6 +51,7 @@ def test_all_scores_pipeline(
         relation_dict=None,
         type_offsets=None,
         triples=triples,
+        original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
     )
 
     partition_mode = "h_shard" if corruption_scheme == "t" else "t_shard"

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -34,6 +34,7 @@ ds = KGDataset(
     relation_dict=None,
     type_offsets={str(i): o for i, o in enumerate(type_offsets)},
     triples=triples,
+    original_triple_ids={k: np.arange(v.shape[0]) for k, v in triples.items()},
     neg_heads=neg_heads,
     neg_tails=neg_tails,
 )


### PR DESCRIPTION
When creating datasets with random train/valid/test splitting with `KGDataset.from_triples` and `KGDataset.from_dataframe`, for downstream tasks (e.g. comparing predictions with edge graph statistics) it can be useful to keep track of the shuffling and splitting of the original triple IDs in the `(n_triple, 3)` array/df.