### PR TITLE
Candidate entities for scoring in pipeline

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -189,17 +189,12 @@ def test_all_scores_pipeline(
     assert torch.all(cpu_preds == out["topk_global_id"])
 
     if filter_candidates:
+        # check that all predictions are in set of candidates
         assert np.all(np.in1d(out["topk_global_id"], compl_candidates))
         assert np.all(np.in1d(cpu_preds, compl_candidates))
 
         cpu_scores = cpu_scores[:, compl_candidates]
         out["scores"] = out["scores"][:, compl_candidates]
-        # cpu_ranks = cpu_ranks[
-        #     np.in1d(triple_reordered[:, ground_truth_col], compl_candidates)
-        # ]
-        # out["ranks"] = out["ranks"][
-        #     np.in1d(triple_reordered[:, ground_truth_col], compl_candidates)
-        # ]
 
     assert_close(cpu_scores, out["scores"], atol=1e-3, rtol=1e-4)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -146,7 +146,9 @@ def test_all_scores_pipeline(
     if filter_candidates:
         # positive score -inf if ground truth not in candidate list
         pos_scores[
-            ~np.in1d(triple_reordered[:, ground_truth_col], compl_candidates)
+            torch.from_numpy(
+                ~np.in1d(triple_reordered[:, ground_truth_col], compl_candidates)
+            )
         ] = -torch.inf
 
     # mask positive scores to compute metrics


### PR DESCRIPTION
Add feature to allow restricting scoring in `AllScoresPipeline` to a specific set of candidate heads/tails provided by the user. This implies that all predicted entities for completions are within this particular set.

TODO: it would be more efficient to just compute the scores for these candidate entities, instead of scoring everything and then masking the scores for entities not in the candidate set. This requires tweaking the `AllScoresBESS` module, supporting a custom `candidate_sampler`. In the case where we also want to filter triples, the filter generation would also need to be adjusted.